### PR TITLE
Remove secrets from `.env`!

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,6 @@
 
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL=postgres://mpynpxndkqwcsp:b16fb70e4e51bf43cdeb67268d51734d24dd4d310ae142c21a62af477ec94864@ec2-3-232-22-121.compute-1.amazonaws.com:5432/d7a17j3qummm26
-GOOGLE_CLIENT_ID="424753703228-hu2vgd8fo3h2vsskumvhblpr3cjj5cne.apps.googleusercontent.com"
-GOOGLE_CLIENT_SECRET="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"
+DATABASE_URL=postgres://mpyn...m26
+GOOGLE_CLIENT_ID="424...om"
+GOOGLE_CLIENT_SECRET="G...Vd"


### PR DESCRIPTION
The `.env` file usually should not be checked into Git but in `.gitignore`.
If the above secrets are real, you should _asap_ disable/invalidate them so no one can abuse them. Just removing the values here in Git will not prevent that.